### PR TITLE
Make product marker human readable

### DIFF
--- a/src/sdmon.c
+++ b/src/sdmon.c
@@ -564,7 +564,7 @@ int main(int argc, const char *argv[]) {
   printf("\"powerUpCount\": %ld,\n", (long)((data_in[112] << 24) + (data_in[113] << 16) + (data_in[114] << 8) + data_in[115]));
   printf("\"abnormalPowerOffCount\": %d,\n", (int)((data_in[128] << 8) + data_in[129]));
   printf("\"totalRefreshCount\": %d,\n", (int)((data_in[160] << 8) + data_in[161]));
-  printf("\"productMarker\": "%c%c%c%c%c%c%c%c,\n", data_in[176], data_in[177], data_in[178], data_in[179], data_in[180], data_in[181], data_in[182], data_in[183]);
+  printf("\"productMarker\": "%c%c%c%c%c%c%c%c\n", data_in[176], data_in[177], data_in[178], data_in[179], data_in[180], data_in[181], data_in[182], data_in[183]);
   //  printf("\"badBlockCountPerDie2\": "
   //         "[\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\","
   //         "\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\","

--- a/src/sdmon.c
+++ b/src/sdmon.c
@@ -564,10 +564,7 @@ int main(int argc, const char *argv[]) {
   printf("\"powerUpCount\": %ld,\n", (long)((data_in[112] << 24) + (data_in[113] << 16) + (data_in[114] << 8) + data_in[115]));
   printf("\"abnormalPowerOffCount\": %d,\n", (int)((data_in[128] << 8) + data_in[129]));
   printf("\"totalRefreshCount\": %d,\n", (int)((data_in[160] << 8) + data_in[161]));
-  printf("\"productMarker\": "
-         "[\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\","
-         "\"0x%02x\",\"0x%02x\"],\n",
-         data_in[176], data_in[177], data_in[178], data_in[179], data_in[180], data_in[181], data_in[182], data_in[183]);
+  printf("\"productMarker\": "%c%c%c%c%c%c%c%c,\n", data_in[176], data_in[177], data_in[178], data_in[179], data_in[180], data_in[181], data_in[182], data_in[183]);
   //  printf("\"badBlockCountPerDie2\": "
   //         "[\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\","
   //         "\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\","


### PR DESCRIPTION
Tested on Delkin utility card on my T6 board:

{
"version": "abcd23",
"date": "2024-01-13T14:15:25.000Z",
"device":"/dev/mmcblk0",
"addTime": "false",
"read_via_cmd56_arg_1":"read successful but signature 0xff 0xff", "idata.response[]":"0x900 0x00 0x00 0x00",
"flashId": ["0x98","0xde","0x94","0x93","0x76","0x51","0x08","0x04","0x04"], "icVersion": ["0x20","0x12"],
"fwVersion": [82,112],
"ceNumber": "0x01",
"spareBlockCount": 60,
"initialBadBlockCount": 6,
"goodBlockRatePercent": 99.72,
"totalEraseCount": 1153,
"enduranceRemainLifePercent": 100.00,
"avgEraseCount": 1,
"minEraseCount": 1,
"maxEraseCount": 7,
"powerUpCount": 17,
"abnormalPowerOffCount": 0,
"totalRefreshCount": 0,
"productMarker": pSLC,
"laterBadBlockCount": 1,
"success":true
}